### PR TITLE
Implement reject reason dialog and edit capability

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -355,3 +355,8 @@ This implementation allows users to submit equipment reservation requests, which
 - User Concerned: request-management
 - Issue: Duplicate keys in pagination causing React warning
 - Progress: Rewrote page number generation to ensure unique keys.
+
+## Update - Reject Reason & Edit Dialog
+- User Concerned: request-management
+- Issue: Add reject reason workflow and editable view dialog
+- Progress: Implemented reject reason dialog, edit mode in RequestViewDetailsDialog, solid menu style, and removed export/print buttons.

--- a/app/api/requests/details/route.js
+++ b/app/api/requests/details/route.js
@@ -85,6 +85,7 @@ export async function GET(request) {
       requesterCostCenter: requestData.requesterCostCenter,
       urgentType: requestData.urgentType,
       urgencyReason: requestData.urgencyReason,
+      rejectReason: requestData.rejectReason || "",
       progress: 0, // Will be calculated based on samples
     };
 

--- a/app/api/requests/manage/route.ts
+++ b/app/api/requests/manage/route.ts
@@ -77,6 +77,7 @@ export async function GET(request: Request) {
         samples: req.sample_count || 0,
         department: req.department || "Unknown",
         description: req.description || "No description",
+        rejectReason: req.rejectReason || "",
       }));
     }
     
@@ -112,6 +113,7 @@ export async function GET(request: Request) {
         department: req.department || "Unknown",
         description: req.description || "No description",
         equipment: req.equipment_name || "Unknown Equipment",
+        rejectReason: req.rejectReason || "",
       }));
     }
     
@@ -166,18 +168,20 @@ export async function PATCH(request: Request) {
     if (isErRequest) {
       updatedRequest = await ErList.findOneAndUpdate(
         { request_number: id },
-        { 
+        {
           status,
-          ...(note && { note })
+          ...(note && { note }),
+          ...(status === "rejected" && note ? { rejectReason: note } : {}),
         },
         { new: true }
       );
     } else {
       updatedRequest = await RequestList.findOneAndUpdate(
         { request_number: id },
-        { 
+        {
           status,
-          ...(note && { note })
+          ...(note && { note }),
+          ...(status === "rejected" && note ? { rejectReason: note } : {}),
         },
         { new: true }
       );
@@ -229,9 +233,10 @@ export async function PUT(request: Request) {
     if (erIds.length > 0) {
       const result = await ErList.updateMany(
         { request_number: { $in: erIds } },
-        { 
+        {
           status,
           ...(note && { note }),
+          ...(status === "rejected" && note ? { rejectReason: note } : {}),
           updatedAt: new Date()
         }
       );
@@ -242,9 +247,10 @@ export async function PUT(request: Request) {
     if (regularIds.length > 0) {
       const result = await RequestList.updateMany(
         { request_number: { $in: regularIds } },
-        { 
+        {
           status,
           ...(note && { note }),
+          ...(status === "rejected" && note ? { rejectReason: note } : {}),
           updatedAt: new Date()
         }
       );

--- a/models/RequestList.js
+++ b/models/RequestList.js
@@ -26,6 +26,10 @@ const RequestListSchema = new Schema(
       required: true,
       index: true
     },
+    rejectReason: {
+      type: String,
+      description: 'Reason for rejecting the request',
+    },
 
     // Request details
     requestTitle: {


### PR DESCRIPTION
## Summary
- support editing in RequestViewDetailsDialog with save
- add reject reason dialog and icon in request table
- remove export/print options from details dialog
- make dropdown menu solid
- track reject reasons in database schema and API

## Testing
- `npm run lint` *(fails: ESLint must be installed)*
- `npm test` *(fails: jest not found)*