### PR TITLE
Fix request management heading

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -375,3 +375,8 @@ This implementation allows users to submit equipment reservation requests, which
 - User Concerned: request-management
 - Issue: "Receive All" did not transition samples to the correct status
 - Progress: Updated manage and receive API routes to set `in-progress` status for all samples when requests are received.
+
+## Update - Heading Consistency
+- User Concerned: request-management
+- Issue: Request Management page heading differed from homepage
+- Progress: Updated heading text in `/request-management` page to match the homepage heading.

--- a/app/request-management/page.tsx
+++ b/app/request-management/page.tsx
@@ -567,7 +567,7 @@ export default function RequestManagementPage() {
         <div className="container px-4 py-6 md:py-8">
           <div className="flex flex-col md:flex-row justify-between items-start md:items-center gap-4 mb-8">
             <div>
-              <h1 className="text-3xl font-bold tracking-tight">Request Management Hub</h1>
+              <h1 className="text-3xl font-bold tracking-tight">Welcome to PCRD Smart Request System</h1>
               <p className="text-muted-foreground">Manage and track all test requests across the PCRD system</p>
             </div>
 


### PR DESCRIPTION
## Summary
- update Request Management page title to match home page
- document heading change in AGENTS log

## Testing
- `npm run lint` *(fails: ESLint must be installed)*
- `npm test` *(fails: jest: not found)*