### PR TITLE
Add Testing List view in request management

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -380,3 +380,8 @@ This implementation allows users to submit equipment reservation requests, which
 - User Concerned: request-management
 - Issue: Request Management page heading differed from homepage
 - Progress: Updated heading text in `/request-management` page to match the homepage heading.
+
+## Update - Request vs Testing View
+- User Concerned: request-management
+- Issue: Needed ability to switch table between request list and testing list
+- Progress: Added `tableView` toggle with API `/api/testing-lists/manage` and updated page to support both views.

--- a/app/api/testing-lists/manage/route.js
+++ b/app/api/testing-lists/manage/route.js
@@ -1,0 +1,71 @@
+import { NextResponse } from "next/server";
+import dbConnect from "@/lib/dbConnect";
+import TestingSampleList from "@/models/TestingSampleList";
+
+export async function GET(request) {
+  try {
+    const { searchParams } = new URL(request.url);
+    const status = searchParams.get("status") || "all";
+    const search = searchParams.get("search") || "";
+    const capability = searchParams.get("capability") || "all";
+    const page = parseInt(searchParams.get("page") || "1");
+    const limit = parseInt(searchParams.get("limit") || "20");
+    const skip = (page - 1) * limit;
+
+    await dbConnect();
+
+    const filter = {};
+
+    if (status !== "all") {
+      filter.sampleStatus = { $regex: status, $options: "i" };
+    }
+
+    if (search) {
+      filter.$or = [
+        { sampleId: { $regex: search, $options: "i" } },
+        { requestNumber: { $regex: search, $options: "i" } },
+        { sampleName: { $regex: search, $options: "i" } },
+      ];
+    }
+
+    if (capability !== "all") {
+      filter.$or = filter.$or || [];
+      filter.$or.push({ capabilityName: { $regex: capability, $options: "i" } });
+      filter.$or.push({ capabilityId: capability });
+    }
+
+    const [samples, total] = await Promise.all([
+      TestingSampleList.find(filter)
+        .sort({ createdAt: -1 })
+        .skip(skip)
+        .limit(limit)
+        .lean(),
+      TestingSampleList.countDocuments(filter),
+    ]);
+
+    const data = samples.map((sample) => ({
+      id: sample.sampleId,
+      title: sample.sampleName,
+      type: sample.requestNumber,
+      capability: sample.capabilityName,
+      status: sample.sampleStatus,
+      priority: "-",
+      dueDate: sample.dueDate ? new Date(sample.dueDate).toISOString().split("T")[0] : "",
+      progress: 0,
+    }));
+
+    const pages = Math.ceil(total / limit);
+
+    return NextResponse.json({
+      success: true,
+      data,
+      pagination: { total, pages, page, limit },
+    });
+  } catch (error) {
+    console.error("Error in testing list manage API:", error);
+    return NextResponse.json(
+      { success: false, error: error.message || "Failed to fetch testing lists" },
+      { status: 500 }
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- add API route to fetch TestingSampleList data
- enable switching between request list and testing list on Request Management page
- update agent notes about new feature

## Testing
- `npm run lint` *(fails: ESLint must be installed)*
- `npm test` *(fails: jest not found)*